### PR TITLE
fixed a typo to rename FRAME_TYPE_STATUS_CHANGE

### DIFF
--- a/example/recv_audio_16bpp.py
+++ b/example/recv_audio_16bpp.py
@@ -64,7 +64,7 @@ def main():
             ndi.recv_free_metadata(ndi_recv, m)
             continue
 
-        if t == ndi.FRANE_TYPE_STATUS_CHANGE:
+        if t == ndi.FRAME_TYPE_STATUS_CHANGE:
             print('Receiver connection status changed.')
             continue
 

--- a/example/recv_audio_sd.py
+++ b/example/recv_audio_sd.py
@@ -80,7 +80,7 @@ def main():
                 ndi.recv_free_metadata(ndi_recv, m)
                 continue
 
-            if t == ndi.FRANE_TYPE_STATUS_CHANGE:
+            if t == ndi.FRAME_TYPE_STATUS_CHANGE:
                 print('Receiver connection status changed.')
                 continue
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,7 +16,7 @@ PYBIND11_MODULE(NDIlib, m) {
       .value("FRAME_TYPE_AUDIO", NDIlib_frame_type_audio)
       .value("FRAME_TYPE_METADATA", NDIlib_frame_type_metadata)
       .value("FRAME_TYPE_ERROR", NDIlib_frame_type_error)
-      .value("FRANE_TYPE_STATUS_CHANGE", NDIlib_frame_type_status_change)
+      .value("FRAME_TYPE_STATUS_CHANGE", NDIlib_frame_type_status_change)
       .value("FRAME_TYPE_MAX", NDIlib_frame_type_max)
       .export_values();
 


### PR DESCRIPTION
I just stumbled onto a type in the code where FRA**N**E_TYPE_STATUS_CHANGE should be FRA**M**E_TYPE_STATUS_CHANGE